### PR TITLE
Allow emails in profile

### DIFF
--- a/assets/scss/_profile.scss
+++ b/assets/scss/_profile.scss
@@ -121,6 +121,20 @@
         width: 100%;
       }
 
+      .email {
+        cursor: pointer;
+        position: relative;
+
+        span {
+          display: inline-block;
+          text-decoration: underline;
+
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+
       .social-icon {
         padding-left: 5px;
       }
@@ -181,7 +195,7 @@
         right: 0;
         top: 300px;
         overflow: hidden;
-        width: 20%;
+        width: 30%;
         height: 200px;
         padding: 20px 10px 0 0;
       }

--- a/content/spaces/leipzig/kristin-fritsch/index.de.md
+++ b/content/spaces/leipzig/kristin-fritsch/index.de.md
@@ -9,6 +9,7 @@ website: https://kristin-fritsch.de
 github: twissi
 meetme: OpenTechSchool Leipzig
 meetmelink: https://www.meetup.com/OpenTechSchool-Leipzig/
+email: dev@kristin-fritsch.de
 ---
 
 # Ein paar Worte zu dir, wer bist du?

--- a/content/spaces/leipzig/kristin-fritsch/index.en.md
+++ b/content/spaces/leipzig/kristin-fritsch/index.en.md
@@ -9,6 +9,7 @@ website: https://kristin-fritsch.de
 github: twissi
 meetme: OpenTechSchool Leipzig
 meetmelink: https://www.meetup.com/OpenTechSchool-Leipzig/
+email: dev@kristin-fritsch.de
 ---
 
 # A few words about you, who are you?

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -63,3 +63,6 @@ other = "Zeig dich!"
 
 [website]
 other = "Webseite"
+
+[email]
+other = "E-Mail"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -75,3 +75,6 @@ other = "Website"
 
 [zeigdich]
 other = "Show yourself!"
+
+[email]
+other = "Email"

--- a/layouts/partials/obfuscated-email.html
+++ b/layouts/partials/obfuscated-email.html
@@ -1,0 +1,25 @@
+<!-- https://www.blackcap.site/posts/obfuscate/ -->
+
+{{ $encoded := (.email | htmlEscape | markdownify | base64Encode) }}
+{{ $halfLength := div (len $encoded) 2 }}
+
+{{ $part1 := substr $encoded 0 $halfLength }}
+{{ $part2 := substr $encoded $halfLength }}
+
+<div id="mangled_{{ md5 $encoded }}" class="email">
+  <span>{{ i18n "email" }}</span>
+  <i class="fas fa-envelope social-icon"></i>
+</div>
+<script>
+  (() => {
+    var base64ToUnicode = str => decodeURIComponent(atob(str).split("").map(c => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2)).join(""));
+    document.addEventListener("DOMContentLoaded", () => {
+      var element = document.getElementById("mangled_{{ md5 $encoded }}");
+      element.addEventListener("click", (e) => {
+        var email = base64ToUnicode({{ $part1 }} + {{ $part2 }});
+        element.querySelector("span").innerHTML = email;
+      });
+    });
+  })();
+</script>
+

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -37,6 +37,7 @@
       {{ if isset .Params "twitter" }} <a href="https://www.twitter.com/{{ .Params.twitter }}" target="_blank" rel="noopener noreferrer">@{{ .Params.twitter }}<i class="fab fa-twitter social-icon"></i></a> {{ end }}
       {{ if isset .Params "instagram" }} <a href="https://www.instagram.com/{{ .Params.instagram }}" target="_blank" rel="noopener noreferrer">@{{ .Params.instagram }}<i class="fab fa-instagram social-icon"></i></a> {{ end }}
       {{ if isset .Params "facebook" }} <a href="https://www.facebook.com/{{ .Params.facebook }}" target="_blank" rel="noopener noreferrer">@{{ .Params.facebook }}<i class="fab fa-facebook social-icon"></i></a> {{ end }}
+      {{ if isset .Params "email" }} {{- partial "obfuscated-email.html" (dict "email" .Params.email) -}} {{ end }}
     </div>
     <div class="footer-nav">
       {{ if or (.PrevInSection) (.NextInSection) }}


### PR DESCRIPTION
Show email addresses on profile page.
This was a feature request from Katharina.

Because we don't want to show emails in plaintext on the website, I looked at different examples on how to obfuscate the email address. The well known way of writing email like `xyz [ät] gmail.com` isn't good enough, because bots can still look for `[ät]` or `mailto:` links.

I looked at different examples and played around with this [example](https://www.blackcap.site/posts/obfuscate/). I modified the example a little bit to only show the email in cleartext after the user click the link. I don't believe bots will click elements that are not links.
